### PR TITLE
Setup mailserver Docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # GestioneTicketsEnv
+
+This repository provides a Docker environment that includes a simple SMTP server with webmail and a local DNS service. It can be used for development or adapted for production deployments.
+
+## Components
+
+- **Bind9**: local DNS server used to expose an MX record for `example.local`.
+- **Docker Mailserver**: provides Postfix and Dovecot for sending/receiving mail.
+- **Roundcube**: web interface to read emails.
+
+All services run in the `mailnet` network and expose minimal ports for local usage.
+
+## Usage
+
+1. Create a mailbox using the setup utility:
+   ```bash
+   docker compose run --rm mail setup email add user@example.local password
+   ```
+2. Start the stack:
+   ```bash
+   docker compose up -d
+   ```
+3. Point your system DNS to the container `dns` (e.g., `127.0.0.1`) so that the backend can resolve the `example.local` domain.
+4. Access Roundcube at <http://localhost:8080> and log in with the credentials created above.
+
+This environment is ready for local development. Adjust domain names and credentials in `docker-compose.yml`, `dns` configuration and `mailserver.env` for production deployment.

--- a/dns/named.conf
+++ b/dns/named.conf
@@ -1,0 +1,11 @@
+options {
+  directory "/var/cache/bind";
+  recursion yes;
+  allow-query { any; };
+  listen-on port 53 { any; };
+};
+
+zone "example.local" IN {
+  type master;
+  file "/etc/bind/zones/db.example.local";
+};

--- a/dns/zones/db.example.local
+++ b/dns/zones/db.example.local
@@ -1,0 +1,12 @@
+$TTL 1h
+@   IN SOA ns.example.local. admin.example.local. (
+        1 ; Serial
+        1h ; Refresh
+        15m ; Retry
+        1w ; Expire
+        1h ) ; Negative Cache TTL
+;
+@       IN NS ns.example.local.
+@       IN MX 10 mail.example.local.
+ns      IN A 172.16.238.5
+mail    IN A 172.16.238.10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: '3.8'
+
+services:
+  dns:
+    image: internetsystemsconsortium/bind9:9.18
+    container_name: dns
+    volumes:
+      - ./dns/named.conf:/etc/bind/named.conf
+      - ./dns/zones:/etc/bind/zones
+    networks:
+      mailnet:
+        ipv4_address: 172.16.238.5
+    ports:
+      - "53:53/udp"
+      - "53:53/tcp"
+
+  mail:
+    image: mailserver/docker-mailserver:latest
+    container_name: mail
+    hostname: mail
+    domainname: example.local
+    env_file: mailserver.env
+    volumes:
+      - ./data/maildata:/var/mail
+      - ./data/mailstate:/var/mail-state
+      - ./data/maillogs:/var/log/mail
+      - ./config:/tmp/docker-mailserver
+    networks:
+      mailnet:
+        ipv4_address: 172.16.238.10
+    ports:
+      - "25:25"
+      - "587:587"
+      - "993:993"
+    restart: unless-stopped
+    depends_on:
+      - dns
+
+  webmail:
+    image: roundcube/roundcubemail:latest
+    container_name: webmail
+    environment:
+      ROUNDCUBEMAIL_DEFAULT_HOST: mail
+      ROUNDCUBEMAIL_SMTP_SERVER: mail
+    depends_on:
+      - mail
+    networks:
+      mailnet:
+        ipv4_address: 172.16.238.15
+    ports:
+      - "8080:80"
+
+networks:
+  mailnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.238.0/24

--- a/mailserver.env
+++ b/mailserver.env
@@ -1,0 +1,8 @@
+DOMAINNAME=example.local
+HOSTNAME=mail
+POSTMASTER_ADDRESS=postmaster@example.local
+ENABLE_POP3=yes
+ENABLE_CLAMAV=0
+ENABLE_FAIL2BAN=0
+SSL_TYPE=manual
+TLS_FLAVOR=manual


### PR DESCRIPTION
## Summary
- add docker-compose with bind9, docker-mailserver and roundcube
- provide dns zone configuration and default env vars
- document setup steps in README

## Testing
- `python3 - <<'EOF'
import yaml
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('compose valid')
EOF`
- `named-checkconf dns/named.conf`
- `named-checkzone example.local dns/zones/db.example.local`


------
https://chatgpt.com/codex/tasks/task_e_688b2fe3e7b48322b5761e7203b45e20